### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,6 +2,10 @@
 
 name: "Dependabot auto-merge"
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request_target:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/Shamik-07/multi_agent_insurance_expert/security/code-scanning/1](https://github.com/Shamik-07/multi_agent_insurance_expert/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for enabling auto-merge functionality.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `dependabot` job. In this case, adding it at the root level is sufficient and ensures clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
